### PR TITLE
Fix the BROADCAST_DRIVER setting in .env.docker

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -127,8 +127,8 @@ LOG_CHANNEL=stderr
 ## Image
 IMAGE_DRIVER=imagick
 
-## Broadcasting
-BROADCAST_DRIVER=log  # log driver for local development
+## Broadcasting: log driver for local development
+BROADCAST_DRIVER=log
 
 ## Cache
 CACHE_DRIVER=redis


### PR DESCRIPTION
fixes #3597